### PR TITLE
filter out everything which is not type:'context'

### DIFF
--- a/src/utils/matrix.ts
+++ b/src/utils/matrix.ts
@@ -44,7 +44,10 @@ export async function determineModeratedRooms(
 				console.error('Unable to determine user power level in room: ' + room.name);
 				return;
 			}
-			if (userPowerLevel >= moderatorLevel && currentState?.events?.get('dev.medienhaus.meta')?.get('')?.event?.content?.type === 'context') {
+
+			const metaEvents = currentState.getStateEvents('dev.medienhaus.meta', '');
+			const isContext = metaEvents?.getContent().type === 'context';
+			if (isContext && userPowerLevel >= moderatorLevel) {
 				moderatorRooms.push(room);
 			}
 		}

--- a/src/utils/matrix.ts
+++ b/src/utils/matrix.ts
@@ -44,7 +44,7 @@ export async function determineModeratedRooms(
 				console.error('Unable to determine user power level in room: ' + room.name);
 				return;
 			}
-			if (userPowerLevel >= moderatorLevel) {
+			if (userPowerLevel >= moderatorLevel && currentState?.events?.get('dev.medienhaus.meta')?.get('')?.event?.content?.type === 'context') {
 				moderatorRooms.push(room);
 			}
 		}


### PR DESCRIPTION
one liner PR: we are artificially separating different type of matrix spaces with the help of own defined `types` ('context' -> like folders, 'items' -> like files, 'content' -> parts of items) which are defined in the `dev.medienhaus.meta` stateEvent to distinguish their charecteristic. As we only want to show the moderation of spaces in the manner of 'contexts', this PR will filter out all matrix rooms which do not have this stateEvent with this specific type.